### PR TITLE
Optimize CSPRNG a bit

### DIFF
--- a/nufhe/random_numbers.py
+++ b/nufhe/random_numbers.py
@@ -26,11 +26,12 @@ and transfer the result to GPU. The reasons are:
 When it is necessary, the functions can be made to execute on GPU without changing the API.
 """
 
+import numpy
 import random
 
-import numpy
-
+from os import urandom
 from .numeric_functions import double_to_t32, Torus32, Int32
+
 
 
 class DeterministicRNG:
@@ -67,7 +68,7 @@ class SecureRNG:
 
     def uniform_bool(self, shape):
         length = numpy.prod(shape)
-        return numpy.array([self.rng.randrange(0, 2) for i in range(length)], Int32).reshape(shape)
+        return numpy.array([int.from_bytes(urandom(1), 'big') >> 7 for _ in range(length)], Int32).reshape(shape)
 
     def uniform_torus32(self, shape):
         length = numpy.prod(shape)


### PR DESCRIPTION
This PR avoids using the Python `SystemRandom` API for the `uniform_bool` method.

Instead, it reads a single byte from `/dev/urandom` directly and then performs a bitwise right-shift to trim excess bits. I've experienced speedups of about ~2.7x