### PR TITLE
random_numbers: use numpy.fromstring() to generate random numbers from the raw urandom() output

### DIFF
--- a/nufhe/random_numbers.py
+++ b/nufhe/random_numbers.py
@@ -30,8 +30,17 @@ import numpy
 import random
 
 from os import urandom
+from reikna.helpers import min_blocks
+
 from .numeric_functions import double_to_t32, Torus32, Int32
 
+
+# Used to generate uniform floats.
+Float = numpy.dtype('float64')
+MantissaInt = numpy.dtype('uint64') # an integer type that fits all possible mantissa values
+
+BPF = numpy.finfo(Float).nmant + 1 # mantissa size + the implicit constant bit
+RECIP_BPF = 2**(-BPF)
 
 
 class DeterministicRNG:
@@ -68,19 +77,53 @@ class SecureRNG:
 
     def uniform_bool(self, shape):
         length = numpy.prod(shape)
-        return numpy.array([int.from_bytes(urandom(1), 'big') >> 7 for _ in range(length)], Int32).reshape(shape)
+        nbytes = min_blocks(length, 8)
+        random_bytes = numpy.fromstring(urandom(nbytes), numpy.uint8)
+        random_bits = numpy.unpackbits(random_bytes)[:length]
+        return random_bits.reshape(shape).astype(Int32)
 
     def uniform_torus32(self, shape):
         length = numpy.prod(shape)
-        lo = -2**31
-        hi = 2**31
-        return numpy.array(
-            [self.rng.randrange(lo, hi) for i in range(length)], Torus32).reshape(shape)
+        nbytes = length * numpy.dtype(Int32).itemsize
+        return numpy.fromstring(urandom(nbytes), Int32).reshape(shape)
+
+    def _uniform_float(self, length):
+        """
+        Returns an array of uniformly distributed floats in the interval (0, 1)
+        (open at both ends!).
+        """
+
+        # The number of possible values in the interval [0, 1) is
+        # 2**(mantissa size + the implicit constant bit)
+        # (and they are uniformly distributed).
+
+        nbytes = length * MantissaInt.itemsize
+        mantissa_bits = numpy.fromstring(urandom(nbytes), MantissaInt)
+
+        # We want an open interval, so we want to exclude 0 without using rejection sampling.
+        # To do that, we drop an additional bit from our generated integer,
+        # and shift the range from [0, 2^(bpf-1)-1] to [2^(-bpf), 1 - 2^(-bpf)]
+        mantissa_bits >>= (MantissaInt.itemsize * 8 - (BPF - 1))
+        mantissa_bits = mantissa_bits * 2 + 1
+
+        return mantissa_bits * RECIP_BPF
 
     def gauss(self, shape, std_dev):
         length = numpy.prod(shape)
-        return numpy.array(
-            [self.rng.normalvariate(0, std_dev) for i in range(length)]).reshape(shape)
+        assert length % 2 == 0
+
+        # Box-Muller transform
+
+        u1 = self._uniform_float(length // 2)
+        u2 = self._uniform_float(length // 2)
+
+        r = (-2 * numpy.log(u1))**0.5
+        theta = 2 * numpy.pi * u2
+
+        z0 = r * numpy.cos(theta)
+        z1 = r * numpy.sin(theta)
+
+        return numpy.concatenate([z0, z1]).reshape(shape) * std_dev
 
 
 # Gaussian sample centered in message, with standard deviation sigma


### PR DESCRIPTION
This variant works much faster. The `random_bool()` and `random_torus32()` should be fine from the security standpoint, but I have some concerns about the generation of Gaussian numbers:

* Since I need an open interval for floating-point randoms in (0, 1), I have to generate a 52-bit random integer instead of a 53-bit one and do a transform. If one represents all possible float values in [0, 1] (which are uniformly distributed, so the distance between each symbol including 0 and 1 is the same) as

      0 x x x ... x x x 1

  then the elements that can be generated with the transform are

      0 x x x ... x x x 1 
        ^   ^ ... ^   ^   
  
  which works out as uniform for the phase (because 0 and 1 are the same value), but I'm not sure about the radius.

* Box-Muller generates pairs of random normals, which may be correlated if somehow the issue with the uniformness above matters for calculating the radius. We can drop one half of the numbers though, it is still pretty fast.

That said, the `SystemRandom.normalvariate()` implementation uses rejection sampling, so it's vulnerable to side-channel attacks.